### PR TITLE
add separate agent instance type and EbsOptimized

### DIFF
--- a/cfn-pilosa/Makefile
+++ b/cfn-pilosa/Makefile
@@ -3,10 +3,11 @@ CLUSTER_SIZE=3
 NUM_AGENTS=1
 STACK=cluster0
 INSTANCE_TYPE=m3.medium
+AGENT_INSTANCE_TYPE=m3.medium
 AMI=ami-e3c3b8f4
 VPC=vpc-a04897c6
 SUBNET=subnet-5ce57307
-PARAMS=ParameterKey=ClusterName,ParameterValue=$(STACK) ParameterKey=KeyPair,ParameterValue=$(KEY_PAIR) ParameterKey=InstanceType,ParameterValue=$(INSTANCE_TYPE) ParameterKey=AMI,ParameterValue=$(AMI) ParameterKey=VPC,ParameterValue=$(VPC) ParameterKey=Subnet,ParameterValue=$(SUBNET)
+PARAMS=ParameterKey=ClusterName,ParameterValue=$(STACK) ParameterKey=KeyPair,ParameterValue=$(KEY_PAIR) ParameterKey=InstanceType,ParameterValue=$(INSTANCE_TYPE) ParameterKey=AgentInstanceType,ParameterValue=$(AGENT_INSTANCE_TYPE) ParameterKey=AMI,ParameterValue=$(AMI) ParameterKey=VPC,ParameterValue=$(VPC) ParameterKey=Subnet,ParameterValue=$(SUBNET)
 PY_FILE=cfn-pilosa.py
 JSON_FILE=build/cfn-pilosa-$(CLUSTER_SIZE)-$(NUM_AGENTS).json
 BENCHMARK_CONFIG=$(GOPATH)/src/github.com/pilosa/pilosa/cmd/pilosactl/spawn.json

--- a/cfn-pilosa/cfn-pilosa.py
+++ b/cfn-pilosa/cfn-pilosa.py
@@ -59,6 +59,15 @@ class PilosaTemplate(Skel):
         )
 
     @cfparam
+    def agent_instance_type(self):
+        return Parameter(
+            'AgentInstanceType',
+            Description='Instance type of agent nodes',
+            Type='String',
+            Default='c4.large',
+        )
+
+    @cfparam
     def cluster_name(self):
         return Parameter(
             'ClusterName',
@@ -170,6 +179,7 @@ class PilosaTemplate(Skel):
             ImageId = Ref(self.ami), #ubuntu
             InstanceType = Ref(self.instance_type),
             KeyName = Ref(self.key_pair),
+            EbsOptimized=True,
             IamInstanceProfile=Ref(self.instance_profile),
             NetworkInterfaces=[
                 ec2.NetworkInterfaceProperty(
@@ -192,7 +202,7 @@ class PilosaTemplate(Skel):
         return ec2.Instance(
             'PilosaAgentInstance{}'.format(index),
             ImageId=Ref(self.ami), # ubuntu
-            InstanceType=Ref(self.instance_type),
+            InstanceType=Ref(self.agent_instance_type),
             KeyName=Ref(self.key_pair),
             IamInstanceProfile=Ref(self.instance_profile),
             NetworkInterfaces=[


### PR DESCRIPTION
these changes were useful to me when creating clusters for a demo. I used the agent for data ingest and having it be a different instance type allowed me to speed up ingest significantly.