### PR TITLE
multiple setbit

### DIFF
--- a/bench/client.go
+++ b/bench/client.go
@@ -42,6 +42,22 @@ func (h *HasClient) ExecuteQuery(ctx context.Context, index, query string) (*pcl
 	return resp, err
 }
 
+func (h *HasClient) ExecuteBatchQuery(ctx context.Context, index string, queries []string) (*pcli.QueryResponse, error) {
+	idx, err := h.schema.Index(index, nil)
+	if err != nil {
+		return nil, err
+	}
+	var pqlQueries pcli.PQLBatchQuery
+	for _, q := range queries {
+		query := idx.RawQuery(q)
+		pqlQueries.Add(query)
+	}
+
+	query := idx.BatchQuery(&pqlQueries)
+	resp, err := h.client.Query(query, &pcli.QueryOptions{})
+	return resp, err
+}
+
 func (h *HasClient) InitIndex(index string, frame string) error {
 	if h.schema == nil {
 		return fmt.Errorf("You need to call HasClient.Init before InitIndex")

--- a/bench/multiple_setbit.go
+++ b/bench/multiple_setbit.go
@@ -1,0 +1,65 @@
+package bench
+
+import (
+	"fmt"
+
+	"context"
+	"math/rand"
+	"time"
+)
+
+// MultipleSetBits sets multiple bits.
+type MultipleSetBits struct {
+	HasClient
+	Name          string `json:"name"`
+	BaseRowID     int64  `json:"base-row-id"`
+	BaseColumnID  int64  `json:"base-column-id"`
+	RowIDRange    int64  `json:"row-id-range"`
+	ColumnIDRange int64  `json:"column-id-range"`
+	Iterations    int    `json:"iterations"`
+	Seed          int64  `json:"seed"`
+	Index         string `json:"index"`
+	Frame         string `json:"frame"`
+	BatchSize     int    `json:"batch-size"`
+}
+
+// Init adds the agent num to the random seed and initializes the client.
+func (b *MultipleSetBits) Init(hosts []string, agentNum int) error {
+	b.Name = "multiple-setbit"
+	b.Seed = b.Seed + int64(agentNum)
+	err := b.HasClient.Init(hosts, agentNum)
+	if err != nil {
+		return err
+	}
+	return b.InitIndex(b.Index, b.Frame)
+}
+
+// Run runs the MultipleSetBits benchmark
+func (b *MultipleSetBits) Run(ctx context.Context) *Result {
+	src := rand.NewSource(b.Seed)
+	rng := rand.New(src)
+	results := NewResult()
+	if b.client == nil {
+		results.err = fmt.Errorf("No client set for MultipleSetBits")
+		return results
+	}
+
+	var queries []string
+	for i := 0; i < b.BatchSize; i++ {
+		rowID := rng.Int63n(b.RowIDRange)
+		profID := rng.Int63n(b.ColumnIDRange)
+		query := fmt.Sprintf("SetBit(frame='%s', rowID=%d, columnID=%d)", b.Frame, b.BaseRowID+rowID, b.BaseColumnID+profID)
+		queries = append(queries, query)
+	}
+
+	for n := 0; n < b.Iterations; n++ {
+		start := time.Now()
+		_, err := b.ExecuteBatchQuery(ctx, b.Index, queries)
+		results.Add(time.Since(start), nil)
+		if err != nil {
+			results.err = err
+			return results
+		}
+	}
+	return results
+}

--- a/cmd/multiple_setbit.go
+++ b/cmd/multiple_setbit.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/pilosa/tools/bench"
+	"github.com/spf13/cobra"
+)
+
+// NewBenchCommand subcommands
+func NewMultipleSetBitsCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	multipleSetBit := &bench.MultipleSetBits{}
+	multipleSetBitsCmd := &cobra.Command{
+		Use:   "multiple-setbit",
+		Short: "Sets multiple bits.",
+		Long: `Sets multiple bits according to the parameters.
+Agent num modifies random seed`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			hosts, err := flags.GetStringSlice("hosts")
+			if err != nil {
+				return err
+			}
+			agentNum, err := flags.GetInt("agent-num")
+			if err != nil {
+				return err
+			}
+			result := bench.RunBenchmark(context.Background(), hosts, agentNum, multipleSetBit)
+			err = PrintResults(cmd, result, stdout)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	flags := multipleSetBitsCmd.Flags()
+	flags.Int64Var(&multipleSetBit.BaseRowID, "base-row-id", 0, "Minimum row id for bits to be set.")
+	flags.Int64Var(&multipleSetBit.RowIDRange, "row-id-range", 100000, "Number of rows in which to set bits.")
+	flags.Int64Var(&multipleSetBit.BaseColumnID, "base-column-id", 0, "Minimum column id for bits to be set.")
+	flags.Int64Var(&multipleSetBit.ColumnIDRange, "column-id-range", 100000, "Number of columsn in which to set bits.")
+	flags.IntVar(&multipleSetBit.BatchSize, "batch-size", 5000, "Number of set bits per request")
+	flags.Int64Var(&multipleSetBit.Seed, "seed", 1, "Random seed.")
+	flags.IntVar(&multipleSetBit.Iterations, "iterations", 100, "Number of bits to set.")
+	flags.StringVar(&multipleSetBit.Frame, "frame", defaultFrame, "Frame to set bits in.")
+	flags.StringVar(&multipleSetBit.Index, "index", defaultIndex, "Pilosa index to use.")
+	flags.StringVar(&multipleSetBit.ClientType, "client-type", "single", "Can be 'single' (all agents hitting one host) or 'round_robin'")
+	flags.StringVar(&multipleSetBit.ContentType, "content-type", "protobuf", "Can be protobuf or pql.")
+
+	return multipleSetBitsCmd
+}
+
+func init() {
+	benchCommandFns["multiple-setbit"] = NewMultipleSetBitsCommand
+}

--- a/spawn-configs/alldefaults.json
+++ b/spawn-configs/alldefaults.json
@@ -39,6 +39,11 @@
             "num": 1,
             "name": "slice-width",
             "args": ["slice-width"]
+        },
+        {
+            "num": 1,
+            "name": "multiple-setbit",
+            "args": ["multiple-setbit"]
         }
     ]
 }


### PR DESCRIPTION
benchmark set multiple bits in 1 request, make sure number of queries <= `max-writes-per-request` from pilosa server, otherwise `too many write commands` error is thrown.