### PR TITLE
WIP: Range benchmark

### DIFF
--- a/bench/client.go
+++ b/bench/client.go
@@ -42,6 +42,23 @@ func (h *HasClient) ExecuteQuery(ctx context.Context, index, query string) (*pcl
 	return resp, err
 }
 
+func (h *HasClient) ExecuteRange(ctx context.Context, index, frame, field, query string) (*pcli.QueryResponse, error) {
+	idx, err := h.schema.Index(index, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	fr, err := idx.Frame(frame, &pcli.FrameOptions{})
+	if err != nil {
+		return nil, err
+	}
+	pqlQuery := pcli.NewPQLBitmapQuery(query, idx, err)
+	sumQuery := fr.Sum(pqlQuery, field)
+	resp, err := h.client.Query(sumQuery, &pcli.QueryOptions{})
+	return resp, err
+
+}
+
 func (h *HasClient) InitIndex(index string, frame string) error {
 	if h.schema == nil {
 		return fmt.Errorf("You need to call HasClient.Init before InitIndex")

--- a/bench/client.go
+++ b/bench/client.go
@@ -3,7 +3,7 @@ package bench
 import (
 	"context"
 	"fmt"
-
+	"errors"
 	pcli "github.com/pilosa/go-pilosa"
 )
 
@@ -74,20 +74,22 @@ func (h *HasClient) InitIndex(index string, frame string) error {
 	return h.client.SyncSchema(h.schema)
 }
 
-func (h *HasClient) InitRange(index, frame, field string, maxValue, minValue int64) error {
+func (h *HasClient) InitRange(index, frame, field string, minValue, maxValue int64) error {
 	if h.schema == nil {
-		return fmt.Errorf("You need to call HasClient.Init before InitIndex")
+		return errors.New("You need to call HasClient.Init before InitRange.")
 	}
 	idx, err := h.schema.Index(index, &pcli.IndexOptions{})
 	if err != nil {
 		return err
 	}
+
 	options := &pcli.FrameOptions{}
 	options.AddIntField(field, int(minValue), int(maxValue))
 	_, err = idx.Frame(frame, options)
 	if err != nil {
 		return err
 	}
+
 	return h.client.SyncSchema(h.schema)
 }
 

--- a/bench/import_range.go
+++ b/bench/import_range.go
@@ -39,7 +39,7 @@ type ValueIterator struct {
 	fdelta           func(z *ValueIterator) float64
 }
 
-// Init generates import range data based on
+// Init create client and range frame.
 func (b *ImportRange) Init(hosts []string, agentNum int) error {
 	if len(hosts) == 0 {
 		return fmt.Errorf("Need at least one host")
@@ -52,7 +52,7 @@ func (b *ImportRange) Init(hosts []string, agentNum int) error {
 		return fmt.Errorf("client init: %v", err)
 	}
 
-	return b.InitRange(b.Index, b.Frame, b.Field, b.MaxValue, b.MinValue)
+	return b.InitRange(b.Index, b.Frame, b.Field, b.MinValue, b.MaxValue)
 }
 
 // Run runs the ImportRange benchmark

--- a/bench/import_range.go
+++ b/bench/import_range.go
@@ -1,0 +1,107 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"github.com/pilosa/go-pilosa"
+	"io"
+	"math/rand"
+)
+
+type ImportRange struct {
+	Name         string `json:"name"`
+	MinValue     int64  `json:"min-value"`
+	MinColumnID  int64  `json:"min-column-id"`
+	MaxValue     int64  `json:"max-value"`
+	MaxColumnID  int64  `json:"max-column-id"`
+	Index        string `json:"index"`
+	Frame        string `json:"frame"`
+	Field        string `json:"field"`
+	Iterations   int64  `json:"iterations"`
+	Seed         int64  `json:"seed"`
+	Distribution string `json:"distribution"`
+	BufferSize   uint
+	rng          *rand.Rand
+	HasClient
+}
+
+type ValueIterator struct {
+	actualIterations int64
+	bitnum           int64
+	maxbitnum        int64
+	minvalue         int64
+	maxvalue         int64
+	mincol           int64
+	maxcol           int64
+	avgdelta         float64
+	lambda           float64
+	rng              *rand.Rand
+	fdelta           func(z *ValueIterator) float64
+}
+
+// Init generates import range data based on
+func (b *ImportRange) Init(hosts []string, agentNum int) error {
+	if len(hosts) == 0 {
+		return fmt.Errorf("Need at least one host")
+	}
+	b.Name = "import-range"
+	b.Seed = b.Seed + int64(agentNum)
+	b.rng = rand.New(rand.NewSource(b.Seed))
+	err := b.HasClient.Init(hosts, agentNum)
+	if err != nil {
+		return fmt.Errorf("client init: %v", err)
+	}
+
+	return b.InitRange(b.Index, b.Frame, b.Field, b.MaxValue, b.MinValue)
+}
+
+// Run runs the ImportRange benchmark
+func (b *ImportRange) Run(ctx context.Context) *Result {
+	results := NewResult()
+
+	valueIterator := b.NewValueIterator()
+	err := b.HasClient.ImportRange(b.Index, b.Frame, b.Field, valueIterator, b.BufferSize)
+	if err != nil {
+		results.err = fmt.Errorf("running go client import: %v", err)
+	}
+	results.Extra["actual-iterations"] = valueIterator.actualIterations
+	results.Extra["avgdelta"] = valueIterator.avgdelta
+	return results
+}
+
+func (b *ImportRange) NewValueIterator() *ValueIterator {
+	z := &ValueIterator{}
+	z.rng = b.rng
+	z.maxbitnum = (b.MaxValue - b.MinValue + 1) * (b.MaxColumnID - b.MinColumnID + 1)
+	z.avgdelta = float64(z.maxbitnum) / float64(b.Iterations)
+	z.minvalue, z.mincol, z.maxvalue, z.maxcol = b.MinValue, b.MinColumnID, b.MaxValue, b.MaxColumnID
+
+	if b.Distribution == "exponential" {
+		z.lambda = 1.0 / z.avgdelta
+		z.fdelta = func(z *ValueIterator) float64 {
+			return z.rng.ExpFloat64() / z.lambda
+		}
+	} else { // if b.Distribution == "uniform" {
+		z.fdelta = func(z *ValueIterator) float64 {
+			return z.rng.Float64() * z.avgdelta * 2
+		}
+	}
+	return z
+}
+
+func (z *ValueIterator) NextValue() (pilosa.FieldValue, error) {
+	delta := z.fdelta(z)
+	if delta < 1.0 {
+		delta = 1.0
+	}
+	z.bitnum = int64(float64(z.bitnum) + delta)
+	if z.bitnum > z.maxbitnum {
+		return pilosa.FieldValue{}, io.EOF
+	}
+
+	field := pilosa.FieldValue{}
+	z.actualIterations++
+	field.Value = uint64((z.bitnum / (z.maxcol - z.mincol + 1)) + z.minvalue)
+	field.ColumnID = uint64(z.bitnum%(z.maxcol-z.mincol+1) + z.mincol)
+	return field, nil
+}

--- a/bench/query.go
+++ b/bench/query.go
@@ -143,7 +143,7 @@ func (q *QueryGenerator) RandomRangeQuery(depth, maxargs int, frame, field strin
 	}
 }
 
-func (q *QueryGenerator) RandomRange(numArg int, field string, idmin, idmax uint64)  *pql.Call{
+func (q *QueryGenerator) RandomRange(numArg int, field string, idmin, idmax uint64) *pql.Call {
 	call := q.R.Intn(4)
 	if call == 0 {
 		return q.RangeCall(field, idmin, idmax)
@@ -165,18 +165,18 @@ func (q *QueryGenerator) RandomRange(numArg int, field string, idmin, idmax uint
 	return nil
 }
 
-func (q *QueryGenerator) RangeCall(field string, idmin, idmax uint64)  *pql.Call{
+func (q *QueryGenerator) RangeCall(field string, idmin, idmax uint64) *pql.Call {
 
 	var operations = []pql.Token{pql.GT, pql.LT, pql.GTE, pql.LTE}
 	opIndex := q.R.Intn(len(operations))
 	frameIdx := q.R.Intn(len(q.Frames))
 
-	condition := pql.Condition{operations[opIndex], q.R.Intn(int(idmax-idmin))}
+	condition := pql.Condition{operations[opIndex], q.R.Intn(int(idmax - idmin))}
 	return &pql.Call{
 		Name: "Range",
 		Args: map[string]interface{}{
 			"frame": q.Frames[frameIdx],
-			field: &condition,
+			field:   &condition,
 		},
 	}
 }
@@ -215,8 +215,6 @@ func (q *QueryGenerator) RandomSum(depth, maxargs int, frame, field string, idmi
 	}
 
 }
-
-
 
 // RandomTopN returns a randomly generated TopN query.
 func (q *QueryGenerator) RandomTopN(maxN, depth, maxargs int, idmin, idmax uint64) *pql.Call {

--- a/bench/query.go
+++ b/bench/query.go
@@ -132,10 +132,9 @@ func (q *QueryGenerator) Random(maxN, depth, maxargs int, idmin, idmax uint64) *
 	}
 }
 
-// RandomRangeQuery returns a randomly generated either sum/range query.
+// RandomRangeQuery returns a randomly generated sum or range query.
 func (q *QueryGenerator) RandomRangeQuery(depth, maxargs int, frame, field string, idmin, idmax uint64) *pql.Call {
-	val := q.R.Intn(5)
-	switch val {
+	switch q.R.Intn(5) {
 	case 1:
 		return q.RandomSum(depth, maxargs, frame, field, idmin, idmax)
 	default:
@@ -167,11 +166,25 @@ func (q *QueryGenerator) RandomRange(numArg int, field string, idmin, idmax uint
 
 func (q *QueryGenerator) RangeCall(field string, idmin, idmax uint64) *pql.Call {
 
-	var operations = []pql.Token{pql.GT, pql.LT, pql.GTE, pql.LTE}
+	var operations = []pql.Token{pql.GT, pql.LT, pql.GTE, pql.LTE, pql.EQ, pql.BETWEEN}
 	opIndex := q.R.Intn(len(operations))
 	frameIdx := q.R.Intn(len(q.Frames))
+	condition := pql.Condition{operations[opIndex], nil}
+	if operations[opIndex] == pql.BETWEEN {
+		var minVal int64
+		maxVal := q.R.Int63n(int64(idmax - idmin))
+		if maxVal > int64(idmin) {
+			minVal = q.R.Int63n(maxVal - int64(idmin))
+		} else {
+			maxVal = int64(idmax)
+		}
+		betweenVal := []interface{}{minVal, maxVal}
+		condition.Value = betweenVal
 
-	condition := pql.Condition{operations[opIndex], q.R.Intn(int(idmax - idmin))}
+	} else {
+		condition.Value = q.R.Intn(int(idmax - idmin))
+	}
+
 	return &pql.Call{
 		Name: "Range",
 		Args: map[string]interface{}{
@@ -184,36 +197,22 @@ func (q *QueryGenerator) RangeCall(field string, idmin, idmax uint64) *pql.Call 
 // RandomSum returns a randomly generated sum query.
 func (q *QueryGenerator) RandomSum(depth, maxargs int, frame, field string, idmin, idmax uint64) *pql.Call {
 	frameIdx := q.R.Intn(len(q.Frames))
-	val := q.R.Intn(5)
-	switch val {
+	pqlQuery := pql.Call{
+		Name: "Sum",
+		Args: map[string]interface{}{
+			"frame": q.Frames[frameIdx],
+			"field": field,
+		}}
+	switch q.R.Intn(5) {
 	case 0:
-		return &pql.Call{
-			Name: "Sum",
-			Args: map[string]interface{}{
-				"frame": q.Frames[frameIdx],
-				"field": field,
-			},
-		}
+		return &pqlQuery
 	case 1:
-		return &pql.Call{
-			Name: "Sum",
-			Args: map[string]interface{}{
-				"frame": q.Frames[frameIdx],
-				"field": field,
-			},
-			Children: []*pql.Call{q.RandomBitmapCall(depth, maxargs, idmin, idmax)},
-		}
+		pqlQuery.Children = []*pql.Call{q.RandomBitmapCall(depth, maxargs, idmin, idmax)}
+		return &pqlQuery
 	default:
-		return &pql.Call{
-			Name: "Sum",
-			Args: map[string]interface{}{
-				"frame": q.Frames[frameIdx],
-				"field": field,
-			},
-			Children: []*pql.Call{q.RandomRange(maxargs, field, idmin, idmax)},
-		}
+		pqlQuery.Children = []*pql.Call{q.RandomRange(maxargs, field, idmin, idmax)}
+		return &pqlQuery
 	}
-
 }
 
 // RandomTopN returns a randomly generated TopN query.

--- a/bench/range.go
+++ b/bench/range.go
@@ -54,7 +54,6 @@ func (b *RangeQuery) Run(ctx context.Context) *Result {
 		}
 		call := qm.RandomRangeQuery(b.MaxDepth, b.MaxArgs, b.Frame, b.Fields[field], uint64(b.MinRange), uint64(b.MaxRange))
 
-		fmt.Println(call.String())
 		start = time.Now()
 		_, err := b.ExecuteQuery(ctx, b.Index, call.String())
 		results.Add(time.Since(start), nil)

--- a/bench/range.go
+++ b/bench/range.go
@@ -1,0 +1,65 @@
+package bench
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+// RangeQuery runs Range query randomly
+type RangeQuery struct {
+	HasClient
+	Name       string   `json:"name"`
+	MaxDepth   int      `json:"max-depth"`
+	MaxArgs    int      `json:"max-args"`
+	MaxN       int      `json:"max-n"`
+	MinRange   int64    `json:"min-range"`
+	MaxRange   int64    `json:"max-range"`
+	Iterations int      `json:"iterations"`
+	Seed       int64    `json:"seed"`
+	Frame      string   `json:"frame"`
+	Index      string   `json:"index"`
+	Fields     []string `json:"field"`
+}
+
+// Init adds the agent num to the random seed and initializes the client.
+func (b *RangeQuery) Init(hosts []string, agentNum int) error {
+	b.Name = "range-query"
+	b.Seed = b.Seed + int64(agentNum)
+	return b.HasClient.Init(hosts, agentNum)
+}
+
+// Run runs the RandomQuery benchmark
+func (b *RangeQuery) Run(ctx context.Context) *Result {
+	src := rand.NewSource(b.Seed)
+	rng := rand.New(src)
+	results := NewResult()
+	if b.client == nil {
+		results.err = fmt.Errorf("No client set for RangeQuery")
+		return results
+	}
+	qm := NewQueryGenerator(b.Seed)
+	qm.IDToFrameFn = func(id uint64) string { return b.Frame }
+
+	var start time.Time
+	for n := 0; n < b.Iterations; n++ {
+		rangeValue := rng.Int63n(b.MaxRange - b.MinRange)
+		var field int
+		if len(b.Fields) > 1 {
+			field = rng.Intn(len(b.Fields) - 1)
+		} else {
+			field = 0
+		}
+		query := fmt.Sprintf("Range(frame='%s', %s<%d)", b.Frame, b.Fields[field], rangeValue)
+
+		start = time.Now()
+		_, err := b.ExecuteQuery(ctx, b.Index, query)
+		results.Add(time.Since(start), nil)
+		if err != nil {
+			results.err = fmt.Errorf("Executing '%s', err: %v", query, err)
+			return results
+		}
+	}
+	return results
+}

--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -12,8 +12,10 @@ import (
 var benchCommandFns = map[string]func(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command{}
 
 const (
-	defaultIndex = "ibench"
-	defaultFrame = "fbench"
+	defaultIndex      = "ibench"
+	defaultFrame      = "fbench"
+	defaultRangeFrame = "range-frame"
+	defaultField      = "range-field"
 )
 
 // NewBenchCommand subcommands

--- a/cmd/import_range.go
+++ b/cmd/import_range.go
@@ -39,7 +39,7 @@ func NewImportRangeCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Com
 	flags.Int64Var(&importer.MinColumnID, "min-column-id", 0, "Minimum column id of set bits.")
 	flags.Int64Var(&importer.MaxValue, "max-value", 1000, "Maximum row id of set bits.")
 	flags.Int64Var(&importer.MaxColumnID, "max-column-id", 1000, "Maximum column id of set bits.")
-	flags.Int64Var(&importer.Iterations, "iterations", 100000, "Number of bits to set")
+	flags.Int64Var(&importer.Iterations, "iterations", 1000, "Number of bits to set")
 	flags.Int64Var(&importer.Seed, "seed", 0, "Random seed.")
 	flags.StringVar(&importer.Index, "index", defaultIndex, "Pilosa index in which to set bits.")
 	flags.StringVar(&importer.Frame, "frame", defaultRangeFrame, "Pilosa frame in which to set bits.")

--- a/cmd/import_range.go
+++ b/cmd/import_range.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/pilosa/tools/bench"
+	"github.com/spf13/cobra"
+)
+
+// NewBenchCommand subcommands
+func NewImportRangeCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	importer := &bench.ImportRange{}
+	importCmd := &cobra.Command{
+		Use:   "import-range",
+		Short: "Import random field data into Pilosa.",
+		Long:  `import-range generates random data which can be controlled by command line flags and streams it into Pilosa's /import endpoint. Agent num has no effect`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			hosts, err := flags.GetStringSlice("hosts")
+			if err != nil {
+				return err
+			}
+			agentNum, err := flags.GetInt("agent-num")
+			if err != nil {
+				return err
+			}
+			result := bench.RunBenchmark(context.Background(), hosts, agentNum, importer)
+			err = PrintResults(cmd, result, stdout)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	flags := importCmd.Flags()
+	flags.Int64Var(&importer.MinValue, "min-value", 0, "Minimum row id of set bits.")
+	flags.Int64Var(&importer.MinColumnID, "min-column-id", 0, "Minimum column id of set bits.")
+	flags.Int64Var(&importer.MaxValue, "max-value", 1000, "Maximum row id of set bits.")
+	flags.Int64Var(&importer.MaxColumnID, "max-column-id", 1000, "Maximum column id of set bits.")
+	flags.Int64Var(&importer.Iterations, "iterations", 100000, "Number of bits to set")
+	flags.Int64Var(&importer.Seed, "seed", 0, "Random seed.")
+	flags.StringVar(&importer.Index, "index", defaultIndex, "Pilosa index in which to set bits.")
+	flags.StringVar(&importer.Frame, "frame", defaultRangeFrame, "Pilosa frame in which to set bits.")
+	flags.StringVar(&importer.Field, "field", defaultField, "Pilosa field in which to set values.")
+	flags.StringVar(&importer.Distribution, "distribution", "uniform", "Random distribution for deltas between set bits (exponential or uniform).")
+	flags.UintVar(&importer.BufferSize, "buffer-size", 10000000, "Number of set bits to buffer in importer before POSTing to Pilosa.")
+
+	return importCmd
+}
+
+func init() {
+	benchCommandFns["import-range"] = NewImportRangeCommand
+}

--- a/cmd/range.go
+++ b/cmd/range.go
@@ -36,12 +36,11 @@ Agent num modifies random seed.`,
 	}
 
 	flags := rangeQueryCmd.Flags()
-	flags.IntVar(&rangeQuery.MaxDepth, "max-depth", 4, "Maximum nesting of queries.")
-	flags.IntVar(&rangeQuery.MaxArgs, "max-args", 4, "Maximum number of arguments per query.")
-	flags.IntVar(&rangeQuery.MaxN, "max-n", 100, "Maximum value of N for TopN queries.")
+	flags.IntVar(&rangeQuery.MaxDepth, "max-depth", 2, "Maximum nesting of queries.")
+	flags.IntVar(&rangeQuery.MaxArgs, "max-args", 2, "Maximum number of arguments per query.")
 
-	flags.Int64Var(&rangeQuery.MinRange, "min-range", 0, "Minimum row id to include in queries.")
-	flags.Int64Var(&rangeQuery.MaxRange, "max-range", 100000, "Maximum row id to include in queries.")
+	flags.Int64Var(&rangeQuery.MinRange, "min-range", 0, "Minimum range to include in queries.")
+	flags.Int64Var(&rangeQuery.MaxRange, "max-range", 100, "Maximum range to include in queries.")
 	flags.Int64Var(&rangeQuery.Seed, "seed", 1, "random seed")
 	flags.IntVar(&rangeQuery.Iterations, "iterations", 100, "Number queries to perform.")
 	flags.StringVar(&rangeQuery.Frame, "frame", defaultRangeFrame, "Frame to query.")
@@ -49,7 +48,7 @@ Agent num modifies random seed.`,
 	flags.StringSliceVar(&rangeQuery.Fields, "fields", []string{defaultField}, "Pilosa fields to use.")
 	flags.StringVar(&rangeQuery.ClientType, "client-type", "single", "Can be 'single' (all agents hitting one host) or 'round_robin'.")
 	flags.StringVar(&rangeQuery.ContentType, "content-type", "protobuf", "Can be protobuf or pql.")
-
+	flags.StringVar(&rangeQuery.QueryType, "type", "sum", "Query type for range, default to sum")
 	return rangeQueryCmd
 }
 

--- a/cmd/range.go
+++ b/cmd/range.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/pilosa/tools/bench"
+	"github.com/spf13/cobra"
+)
+
+// NewBenchCommand subcommands
+func NewRangeQueryCommand(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
+	rangeQuery := &bench.RangeQuery{}
+	rangeQueryCmd := &cobra.Command{
+		Use:   "range-query",
+		Short: "Constructs and performs range queries.",
+		Long: `Constructs and performs range queries.
+Agent num modifies random seed.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			flags := cmd.Flags()
+			hosts, err := flags.GetStringSlice("hosts")
+			if err != nil {
+				return err
+			}
+			agentNum, err := flags.GetInt("agent-num")
+			if err != nil {
+				return err
+			}
+			result := bench.RunBenchmark(context.Background(), hosts, agentNum, rangeQuery)
+			err = PrintResults(cmd, result, stdout)
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
+	flags := rangeQueryCmd.Flags()
+	flags.IntVar(&rangeQuery.MaxDepth, "max-depth", 4, "Maximum nesting of queries.")
+	flags.IntVar(&rangeQuery.MaxArgs, "max-args", 4, "Maximum number of arguments per query.")
+	flags.IntVar(&rangeQuery.MaxN, "max-n", 100, "Maximum value of N for TopN queries.")
+
+	flags.Int64Var(&rangeQuery.MinRange, "min-range", 0, "Minimum row id to include in queries.")
+	flags.Int64Var(&rangeQuery.MaxRange, "max-range", 100000, "Maximum row id to include in queries.")
+	flags.Int64Var(&rangeQuery.Seed, "seed", 1, "random seed")
+	flags.IntVar(&rangeQuery.Iterations, "iterations", 100, "Number queries to perform.")
+	flags.StringVar(&rangeQuery.Frame, "frame", defaultRangeFrame, "Frame to query.")
+	flags.StringVar(&rangeQuery.Index, "indexes", defaultIndex, "Pilosa index to use.")
+	flags.StringSliceVar(&rangeQuery.Fields, "fields", []string{defaultField}, "Pilosa fields to use.")
+	flags.StringVar(&rangeQuery.ClientType, "client-type", "single", "Can be 'single' (all agents hitting one host) or 'round_robin'.")
+	flags.StringVar(&rangeQuery.ContentType, "content-type", "protobuf", "Can be protobuf or pql.")
+
+	return rangeQueryCmd
+}
+
+func init() {
+	benchCommandFns["range-query"] = NewRangeQueryCommand
+}

--- a/creator/remote.go
+++ b/creator/remote.go
@@ -79,7 +79,7 @@ func (c *RemoteCluster) Start() error {
 		if err != nil {
 			return fmt.Errorf("splitting hostport: %v", err)
 		}
-		conf.Host = hostport
+		conf.Bind = hostport
 		conf.DataDir = "~/.pilosa" + port
 
 		// Get client for host


### PR DESCRIPTION
Steps to reproduce a range query bug:

To import range data, run 
```
pi bench import-range
```
data will be import to default index `ibench`, default range frame `range-frame`, default field `range-frame`. Make sure `range-frame` doesn't exist since I'm waiting for Yuce update go-pilosa for adding new fields to existing frame, so fields now need to be an options when creating frame. This imports data randomly from with max-value = 1000, max-column-id=1000 and about 1000 fields.

To generate random query and run:
```
pi bench range-query --max-depth=4 --max-args 2
```
Last query from queries list is an error one and benchmark returns error as following:

```
Difference(Range(frame="range-frame", range-field >= 86), Range(frame="range-frame", range-field > 60))
{
  "stats": {
    "min": 160306,
    "max": 888329,
    "mean": 465223,
    "total-time": 13956581,
    "num": 30,
    "all": []
  },
  "responses": [],
  "extra": {},
  "duration": 17313172,
  "agentnum": 0,
  "pilosa-version": "v0.4.0-538-g576e26c",
  "configuration": {
    "client-type": "single",
    "content-type": "protobuf",
    "name": "range-query",
    "max-depth": 4,
    "max-args": 2,
    "max-n": 0,
    "min-range": 0,
    "max-range": 100,
    "iterations": 100,
    "seed": 1,
    "frame": "range-frame",
    "index": "ibench",
    "field": [
      "range-field"
    ],
    "type": "sum"
  },
  "error": "Executing 'Difference(Range(frame=\"range-frame\", range-field \u003e= 86), Range(frame=\"range-frame\", range-field \u003e 60))', err: proto: can't skip unknown wire type 6 for internal.QueryResponse"
}
```
And pilosa server log error as following:

```
PANIC: runtime error: index out of range
goroutine 843 [running]:
runtime/debug.Stack(0xc4201a80e0, 0x1f4, 0x1afe9e0)
	/usr/local/Cellar/go/1.8.1/libexec/src/runtime/debug/stack.go:24 +0x79
github.com/pilosa/pilosa.(*Handler).ServeHTTP.func1(0x1acb260, 0xc4201a80e0, 0xc420251030)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/handler.go:155 +0x91
panic(0x16e11c0, 0x1afe9e0)
	/usr/local/Cellar/go/1.8.1/libexec/src/runtime/panic.go:489 +0x2cf
encoding/json.(*encodeState).marshal.func1(0xc420531768)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:288 +0x159
panic(0x16e11c0, 0x1afe9e0)
	/usr/local/Cellar/go/1.8.1/libexec/src/runtime/panic.go:489 +0x2cf
encoding/json.(*encodeState).marshal.func1(0xc420531578)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:288 +0x159
panic(0x16e11c0, 0x1afe9e0)
	/usr/local/Cellar/go/1.8.1/libexec/src/runtime/panic.go:489 +0x2cf
github.com/pilosa/pilosa/roaring.(*Iterator).Next(0xc4204f7ea0, 0xc4204f7ea0, 0x0)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/roaring/roaring.go:896 +0x24f
github.com/pilosa/pilosa.(*BitmapSegment).Bits(0xc4206bdec0, 0x0, 0x0, 0x1b2ab58)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/bitmap.go:406 +0x8b
github.com/pilosa/pilosa.(*Bitmap).Bits(0xc4204f7e60, 0xc4204f7e80, 0xc420531138, 0x100f623)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/bitmap.go:259 +0xc6
github.com/pilosa/pilosa.(*Bitmap).MarshalJSON(0xc4204f7e60, 0x176d5e0, 0xc4204f7e60, 0x2f3c118, 0xc4204f7e60, 0xc420531101)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/bitmap.go:245 +0x68
encoding/json.marshalerEncoder(0xc420258790, 0x176d5e0, 0xc4204f7e60, 0x16, 0xc4204f0100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:451 +0x9f
encoding/json.(*encodeState).reflectValue(0xc420258790, 0x176d5e0, 0xc4204f7e60, 0x16, 0xc4204f0100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:323 +0x82
encoding/json.interfaceEncoder(0xc420258790, 0x16cbf80, 0xc42024e3b0, 0x194, 0x16c0100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:617 +0xdb
encoding/json.(*arrayEncoder).encode(0xc42000e958, 0xc420258790, 0x169d920, 0xc420120c40, 0x97, 0x100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:767 +0xf5
encoding/json.(*arrayEncoder).(encoding/json.encode)-fm(0xc420258790, 0x169d920, 0xc420120c40, 0x97, 0x100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:774 +0x64
encoding/json.(*sliceEncoder).encode(0xc42000e978, 0xc420258790, 0x169d920, 0xc420120c40, 0x97, 0x100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:741 +0xc1
encoding/json.(*sliceEncoder).(encoding/json.encode)-fm(0xc420258790, 0x169d920, 0xc420120c40, 0x97, 0x100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:753 +0x64
encoding/json.(*structEncoder).encode(0xc4203283f0, 0xc420258790, 0x171a340, 0xc420120c40, 0x99, 0x1710100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:645 +0x253
encoding/json.(*structEncoder).(encoding/json.encode)-fm(0xc420258790, 0x171a340, 0xc420120c40, 0x99, 0xc420120100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:659 +0x64
encoding/json.(*encodeState).reflectValue(0xc420258790, 0x171a340, 0xc420120c40, 0x99, 0x100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:323 +0x82
encoding/json.(*encodeState).marshal(0xc420258790, 0x171a340, 0xc420120c40, 0x1710100, 0x0, 0x0)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:296 +0xb8
encoding/json.Marshal(0x171a340, 0xc420120c40, 0x171a340, 0xc420120c40, 0x16ce9e0, 0x2bfc00ee9e4, 0x0)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:161 +0x6e
github.com/pilosa/pilosa.(*QueryResponse).MarshalJSON(0xc420120bc0, 0x16ce9e0, 0xc420120bc0, 0x2f3c0f0, 0xc420120bc0, 0xc420531601)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/handler.go:1644 +0xe7
encoding/json.marshalerEncoder(0xc4202586e0, 0x16ce9e0, 0xc420120bc0, 0x16, 0xc420120100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:451 +0x9f
encoding/json.(*encodeState).reflectValue(0xc4202586e0, 0x16ce9e0, 0xc420120bc0, 0x16, 0x100)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:323 +0x82
encoding/json.(*encodeState).marshal(0xc4202586e0, 0x16ce9e0, 0xc420120bc0, 0xc420000100, 0x0, 0x0)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/encode.go:296 +0xb8
encoding/json.(*Encoder).Encode(0xc420531800, 0x16ce9e0, 0xc420120bc0, 0x1ac4420, 0xc4201a80e0)
	/usr/local/Cellar/go/1.8.1/libexec/src/encoding/json/stream.go:193 +0x8e
github.com/pilosa/pilosa.(*Handler).writeJSONQueryResponse(0xc420251030, 0x1acb260, 0xc4201a80e0, 0xc420120bc0, 0x0, 0xc420120bc0)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/handler.go:1094 +0xad
github.com/pilosa/pilosa.(*Handler).writeQueryResponse(0xc420251030, 0x1acb260, 0xc4201a80e0, 0xc4204bc300, 0xc420120bc0, 0xc4204f6d80, 0xc42024e388)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/handler.go:1079 +0xf4
github.com/pilosa/pilosa.(*Handler).handlePostQuery(0xc420251030, 0x1acb260, 0xc4201a80e0, 0xc4204bc300)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/handler.go:300 +0x744
github.com/pilosa/pilosa.(*Handler).(github.com/pilosa/pilosa.handlePostQuery)-fm(0x1acb260, 0xc4201a80e0, 0xc4204bc300)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/handler.go:129 +0x48
net/http.HandlerFunc.ServeHTTP(0xc4202b7b20, 0x1acb260, 0xc4201a80e0, 0xc4204bc300)
	/usr/local/Cellar/go/1.8.1/libexec/src/net/http/server.go:1942 +0x44
github.com/pilosa/pilosa/vendor/github.com/gorilla/mux.(*Router).ServeHTTP(0xc42021aaa0, 0x1acb260, 0xc4201a80e0, 0xc4204bc300)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/vendor/github.com/gorilla/mux/mux.go:114 +0x10c
github.com/pilosa/pilosa.(*Handler).ServeHTTP(0xc420251030, 0x1acb260, 0xc4201a80e0, 0xc4204bc100)
	/Users/lvo/dev/go/src/github.com/pilosa/pilosa/handler.go:163 +0xd8
net/http.serverHandler.ServeHTTP(0xc4200ac790, 0x1acb260, 0xc4201a80e0, 0xc4204bc100)
	/usr/local/Cellar/go/1.8.1/libexec/src/net/http/server.go:2568 +0x92
net/http.(*conn).serve(0xc4201ae000, 0x1acbfa0, 0xc42017f3c0)
	/usr/local/Cellar/go/1.8.1/libexec/src/net/http/server.go:1825 +0x612
created by net/http.(*Server).Serve
	/usr/local/Cellar/go/1.8.1/libexec/src/net/http/server.go:2668 +0x2ce
```
