### PR TITLE
Seebs/permute

### DIFF
--- a/bench/bench.go
+++ b/bench/bench.go
@@ -92,69 +92,6 @@ func ensureSchema(client *pilosa.Client, indexName, fieldName string, opts ...in
 	return index, field, nil
 }
 
-// PermutationGenerator provides a way to pass integer IDs through a permutation
-// map that is pseudorandom but repeatable. This could be done with rand.Perm,
-// but that would require storing a [Iterations]int64 array, which we want to avoid
-// for large values of Iterations.
-// It works by using a Linear Congruence Generator (https://en.wikipedia.org/wiki/Linear_congruential_generator)
-// with modulus m = Iterations,
-// c = an arbitrary prime,
-// a = computed to ensure the full period.
-// relevant stackoverflow: http://cs.stackexchange.com/questions/29822/lazily-computing-a-random-permutation-of-the-positive-integers
-type PermutationGenerator struct {
-	a int64
-	c int64
-	m int64
-}
-
-func NewPermutationGenerator(m int64, seed int64) *PermutationGenerator {
-	// figure out 'a' and 'c', return PermutationGenerator
-	a := LCGmultiplierFromModulus(m, seed)
-	c := int64(22695479)
-	return &PermutationGenerator{a, c, m}
-}
-
-func (p *PermutationGenerator) Next(n int64) int64 {
-	// run one step of the LCG
-	return (n*p.a + p.c) % p.m
-}
-
-// LCG parameters must satisfy three conditions:
-// 1. m and c are relatively prime (satisfied for prime c != m)
-// 2. a-1 is divisible by all prime factors of m
-// 3. a-1 is divisible by 4 if m is divisible by 4
-// Additionally, a seed can be used to select between different permutations
-func LCGmultiplierFromModulus(m int64, seed int64) int64 {
-	factors := primeFactors(m)
-	product := int64(1)
-	for p := range factors {
-		// satisfy condition 2
-		product *= p
-	}
-
-	if m%4 == 0 {
-		// satisfy condition 3
-		product *= 2
-	}
-
-	return product*seed + 1
-}
-
-// Returns map of {integerFactor: count, ...}
-// This is a naive algorithm that will not work well for large prime n.
-func primeFactors(n int64) map[int64]int {
-	factors := make(map[int64]int)
-	for i := int64(2); i <= n; i++ {
-		div, mod := n/i, n%i
-		for mod == 0 {
-			factors[i] += 1
-			n = div
-			div, mod = n/i, n%i
-		}
-	}
-	return factors
-}
-
 // wrapper type to force human-readable JSON output
 type PrettyDuration time.Duration
 

--- a/bench/zipf.go
+++ b/bench/zipf.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pilosa/go-pilosa"
+	"github.com/pilosa/tools/permute"
 )
 
 // ZipfBenchmark sets random bits according to the Zipf-Mandelbrot distribution.
@@ -59,8 +60,8 @@ func (b *ZipfBenchmark) Run(ctx context.Context, client *pilosa.Client, agentNum
 	rowRand := rand.NewZipf(rand.New(rand.NewSource(seed)), b.RowExponent, rowOffset, uint64(b.MaxRowID-b.MinRowID-1))
 	columnOffset := getZipfOffset(b.MaxColumnID-b.MinColumnID, b.ColumnExponent, b.ColumnRatio)
 	columnRand := rand.NewZipf(rand.New(rand.NewSource(seed)), b.ColumnExponent, columnOffset, uint64(b.MaxColumnID-b.MinColumnID-1))
-	rowPerm := NewPermutationGenerator(b.MaxRowID-b.MinRowID, seed)
-	columnPerm := NewPermutationGenerator(b.MaxColumnID-b.MinColumnID, seed+1)
+	rowPerm := permute.NewPermutationGenerator(b.MaxRowID-b.MinRowID, seed)
+	columnPerm := permute.NewPermutationGenerator(b.MaxColumnID-b.MinColumnID, seed+1)
 
 	for n := 0; n < b.Iterations; n++ {
 		// generate IDs from Zipf distribution

--- a/permute/permute.go
+++ b/permute/permute.go
@@ -1,0 +1,64 @@
+package permute
+
+// PermutationGenerator provides a way to pass integer IDs through a permutation
+// map that is pseudorandom but repeatable. This could be done with rand.Perm,
+// but that would require storing a [Iterations]int64 array, which we want to avoid
+// for large values of Iterations.
+// It works by using a Linear Congruence Generator (https://en.wikipedia.org/wiki/Linear_congruential_generator)
+// with modulus m = Iterations,
+// c = an arbitrary prime,
+// a = computed to ensure the full period.
+// relevant stackoverflow: http://cs.stackexchange.com/questions/29822/lazily-computing-a-random-permutation-of-the-positive-integers
+type PermutationGenerator struct {
+	a int64
+	c int64
+	m int64
+}
+
+func NewPermutationGenerator(m int64, seed int64) *PermutationGenerator {
+	// figure out 'a' and 'c', return PermutationGenerator
+	a := LCGmultiplierFromModulus(m, seed)
+	c := int64(22695479)
+	return &PermutationGenerator{a, c, m}
+}
+
+func (p *PermutationGenerator) Next(n int64) int64 {
+	// run one step of the LCG
+	return (n*p.a + p.c) % p.m
+}
+
+// LCG parameters must satisfy three conditions:
+// 1. m and c are relatively prime (satisfied for prime c != m)
+// 2. a-1 is divisible by all prime factors of m
+// 3. a-1 is divisible by 4 if m is divisible by 4
+// Additionally, a seed can be used to select between different permutations
+func LCGmultiplierFromModulus(m int64, seed int64) int64 {
+	factors := primeFactors(m)
+	product := int64(1)
+	for p := range factors {
+		// satisfy condition 2
+		product *= p
+	}
+
+	if m%4 == 0 {
+		// satisfy condition 3
+		product *= 2
+	}
+
+	return product*seed + 1
+}
+
+// Returns map of {integerFactor: count, ...}
+// This is a naive algorithm that will not work well for large prime n.
+func primeFactors(n int64) map[int64]int {
+	factors := make(map[int64]int)
+	for i := int64(2); i <= n; i++ {
+		div, mod := n/i, n%i
+		for mod == 0 {
+			factors[i] += 1
+			n = div
+			div, mod = n/i, n%i
+		}
+	}
+	return factors
+}

--- a/permute/permute.go
+++ b/permute/permute.go
@@ -24,6 +24,43 @@ type PermutationGenerator struct {
 	k         []uint64
 }
 
+// Design notes:
+//
+// This is based on:
+// http://arxiv.org/abs/1208.1176v2
+//
+// This simulates the results of a shuffle in a way allowing a lookup of
+// the results of the shuffle for any given position, in time proportional
+// to a number of "rounds", each of which is 50% likely to swap a slot
+// with another slot. The number of rounds needed to achieve a reasonable
+// probability of safety is log(N)*6 or so.
+//
+// Each permutation is fully defined by a "key", consisting of:
+//   1. A key "KF" naming a value in [0,max) for each round.
+//   2. A series of round functions mapping values in [0,max) to bits,
+//      one for each round.
+// I refer to these as K[r] and F[r]. Thus, K[0] is the index used to
+// compute swap operations four round 0, and F[0] is the series of bits
+// used to determine whether a swap is performed, with F[0][0] being
+// the swap decision for slot 0 in round 0. (Except it probably isn't,
+// because the swap decision is actually made based on the highest index
+// in a pair, to ensure that a swap between A and B always uses the same
+// decision bit.)
+//
+// The AES cipher is used here as a seekable PRNG source. We use AES-128.
+//
+// For K values, we set byte 8 of the plain text to 0x01, and use
+// encoding/binary to dump r into the first 8 bytes of the plain text. The
+// value K[r] is then the first 8 bytes of the resulting value, converted to
+// uint64, mod max. This is slightly biased. We don't care.
+//
+// For F values, we set byte 8 of the plain text to 0x00, and use
+// encoding/binary to dump the slot number into the first 8 bytes. This
+// yields 128 values, which we treat as the values for the first 128 rounds,
+// and then recycle for rounds 129+ if those exist. This is not very
+// secure, but we're already at 1/2^128 chances by that time and don't care.
+// We could probably trim rounds to 64 or so and not lose much data.
+
 // NewPermutationGenerator creates a PermutationGenerator which will
 // generate values in [0,m), given the provided seed.
 func NewPermutationGenerator(max int64, seed int64) (*PermutationGenerator, error) {
@@ -49,12 +86,16 @@ func NewPermutationGenerator(max int64, seed int64) (*PermutationGenerator, erro
 	p.hIn = make([]byte, p.aes.BlockSize())
 	p.hOut = make([]byte, p.aes.BlockSize())
 	p.k = make([]uint64, p.rounds)
+	// use different part of the AES space for the K values than for
+	// the F values later.
+	p.hIn[8] = 0x01
 	for i := uint64(0); i < uint64(p.rounds); i++ {
 		binary.LittleEndian.PutUint64(p.hIn, i)
 		p.aes.Encrypt(p.hOut, p.hIn)
 		crypt := binary.LittleEndian.Uint64(p.hOut)
 		p.k[i] = crypt % uint64(p.max)
 	}
+	p.hIn[8] = 0x00
 	return &p, nil
 }
 

--- a/permute/permute.go
+++ b/permute/permute.go
@@ -1,64 +1,103 @@
 package permute
 
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/binary"
+	"errors"
+	"math/bits"
+	"math/rand"
+)
+
 // PermutationGenerator provides a way to pass integer IDs through a permutation
 // map that is pseudorandom but repeatable. This could be done with rand.Perm,
 // but that would require storing a [Iterations]int64 array, which we want to avoid
 // for large values of Iterations.
-// It works by using a Linear Congruence Generator (https://en.wikipedia.org/wiki/Linear_congruential_generator)
-// with modulus m = Iterations,
-// c = an arbitrary prime,
-// a = computed to ensure the full period.
-// relevant stackoverflow: http://cs.stackexchange.com/questions/29822/lazily-computing-a-random-permutation-of-the-positive-integers
+//
+// Not actually cryptographically secure.
 type PermutationGenerator struct {
-	a int64
-	c int64
-	m int64
+	aes          cipher.Block
+	max          int64
+	counter      int64
+	rounds       int
+	hIn, hOut    []byte
+	hits, values int64
 }
 
-func NewPermutationGenerator(m int64, seed int64) *PermutationGenerator {
-	// figure out 'a' and 'c', return PermutationGenerator
-	a := LCGmultiplierFromModulus(m, seed)
-	c := int64(22695479)
-	return &PermutationGenerator{a, c, m}
-}
-
-func (p *PermutationGenerator) Next(n int64) int64 {
-	// run one step of the LCG
-	return (n*p.a + p.c) % p.m
-}
-
-// LCG parameters must satisfy three conditions:
-// 1. m and c are relatively prime (satisfied for prime c != m)
-// 2. a-1 is divisible by all prime factors of m
-// 3. a-1 is divisible by 4 if m is divisible by 4
-// Additionally, a seed can be used to select between different permutations
-func LCGmultiplierFromModulus(m int64, seed int64) int64 {
-	factors := primeFactors(m)
-	product := int64(1)
-	for p := range factors {
-		// satisfy condition 2
-		product *= p
+// NewPermutationGenerator creates a PermutationGenerator which will
+// generate values in [0,m), given the provided seed.
+func NewPermutationGenerator(max int64, seed int64) (*PermutationGenerator, error) {
+	if max < 1 {
+		return nil, errors.New("period must be positive")
 	}
+	// number of rounds to get "good" results is roughly 6 log N. but that gets
+	// pretty slow, so we use fewer.
+	bits := 64 - bits.LeadingZeros64(uint64(max))
+	p := PermutationGenerator{max: max, rounds: 6 * bits, counter: 0}
 
-	if m%4 == 0 {
-		// satisfy condition 3
-		product *= 2
+	src := rand.NewSource(seed)
+	rnd := rand.New(src)
+	aesKey := make([]byte, 16)
+	n, err := rnd.Read(aesKey)
+	if n != 16 || err != nil {
+		return nil, err
 	}
-
-	return product*seed + 1
+	p.aes, err = aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, err
+	}
+	p.hIn = make([]byte, p.aes.BlockSize())
+	p.hOut = make([]byte, p.aes.BlockSize())
+	return &p, nil
 }
 
-// Returns map of {integerFactor: count, ...}
-// This is a naive algorithm that will not work well for large prime n.
-func primeFactors(n int64) map[int64]int {
-	factors := make(map[int64]int)
-	for i := int64(2); i <= n; i++ {
-		div, mod := n/i, n%i
-		for mod == 0 {
-			factors[i] += 1
-			n = div
-			div, mod = n/i, n%i
+// Next generates the next value from the permutation generator.
+func (p *PermutationGenerator) Next() (ret int64) {
+	return p.nextValue()
+}
+
+// Nth generates the Nth value from the permutation generator. For instance,
+// given a new permutation generator, calling Next() once produces the same
+// value you'd get from calling Nth(0). Calling Next() twice produces the same
+// value as calling Nth(1). The Nth call changes the location of the permutation
+// generator within its sequence.
+func (p *PermutationGenerator) Nth(n int64) (ret int64) {
+	p.counter = n
+	ret = p.nextValue()
+	p.values++
+	return ret
+}
+
+func (p *PermutationGenerator) nextValue() int64 {
+	p.counter++
+	p.counter = int64(uint64(p.counter) % uint64(p.max))
+	x := uint64(p.counter)
+	for i := uint64(1); i <= uint64(p.rounds); i++ {
+		binary.LittleEndian.PutUint64(p.hIn, i)
+		p.aes.Encrypt(p.hOut, p.hIn)
+		crypt := binary.LittleEndian.Uint64(p.hOut)
+		kSubI := crypt % uint64(p.max)
+		xPrime := (kSubI + uint64(p.max) - x) % uint64(p.max)
+		xCaret := x
+		if xPrime > xCaret {
+			xCaret = xPrime
+		}
+		binary.LittleEndian.PutUint64(p.hIn, uint64(p.max)*i+xCaret)
+		p.aes.Encrypt(p.hOut, p.hIn)
+		crypt = binary.LittleEndian.Uint64(p.hOut)
+		fSubI := crypt >> 63
+		if fSubI == 1 {
+			x = xPrime
 		}
 	}
-	return factors
+	p.hits++
+	return int64(x)
+}
+
+// Hits tells you how many values you've gotten, and how many values were
+// generated to get them. Worst-case rounding would be that, for a range of
+// [0,5), the algorithm in use needs to cycle over 16 values -- it rounds up
+// to 2^3, and then to 2^4 because it needs the next even power of 2.
+func (p *PermutationGenerator) Hits() (values int64, hits int64) {
+	return p.values, p.hits
 }

--- a/permute/permute_test.go
+++ b/permute/permute_test.go
@@ -113,8 +113,6 @@ func Benchmark_PermuteCycle(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				_ = p.Next()
 			}
-			v, h := p.Hits()
-			b.Logf("N %d: %d values, %d hits", b.N, v, h)
 		})
 	}
 }

--- a/permute/permute_test.go
+++ b/permute/permute_test.go
@@ -1,0 +1,120 @@
+package permute
+
+import (
+	"fmt"
+	"testing"
+)
+
+func permutationGeneratorOrBust(period int64, seed int64, err string, tb testing.TB) *PermutationGenerator {
+	p, e := NewPermutationGenerator(period, seed)
+	if e != nil {
+		if err == "" || err != e.Error() {
+			tb.Fatalf("unexpected error creating permutation generator: %s", e)
+		}
+		return p
+	}
+	if p == nil {
+		tb.Fatalf("unexpected nil permutation generator without error")
+	}
+	return p
+}
+
+func Test_PermuteCycle(t *testing.T) {
+	sizes := []int64{8, 23, 64, 10000}
+	for _, size := range sizes {
+		p := permutationGeneratorOrBust(size, 0, "", t)
+		seen := make(map[int64]struct{}, size)
+		for i := int64(0); i < size; i++ {
+			n := p.Next()
+			if _, ok := seen[n]; ok {
+				list := make([]int64, len(seen))
+				j := 0
+				for k := range seen {
+					list[j] = k
+					j++
+				}
+				t.Fatalf("size %d: got duplicate entry %d in %v", size, n, list)
+			}
+			seen[n] = struct{}{}
+		}
+	}
+}
+
+func TestPermuteSeed(t *testing.T) {
+	size := int64(129)
+	seeds := int64(8)
+	p := make([]*PermutationGenerator, seeds)
+	seen := make([]map[int64]struct{}, seeds)
+	for s := int64(0); s < seeds; s++ {
+		p[s] = permutationGeneratorOrBust(size, s, "", t)
+		seen[s] = make(map[int64]struct{}, size)
+	}
+	matches := int64(0)
+	v := make([]int64, seeds)
+	for i := int64(0); i < size; i++ {
+		for s := int64(0); s < seeds; s++ {
+			v[s] = p[s].Next()
+			if _, ok := seen[s][v[s]]; ok {
+				t.Fatalf("duplicate entry (size %d, seed %d, entry %d): %d",
+					size, s, i, v[s])
+			}
+			seen[s][v[s]] = struct{}{}
+		}
+		for s := int64(1); s < seeds; s++ {
+			if v[s] == v[s-1] {
+				matches++
+			}
+		}
+	}
+	// assuming number of outcomes is more than about 16, matches are pretty rare if nothing
+	// is wrong.
+	if (matches * 20) > (size * seeds) {
+		t.Fatalf("too many matches: %d values to permute, %d seeds, %d matches seems suspicious.",
+			size, seeds, matches)
+	} else {
+		t.Logf("permuting %d values across %d seeds: %d matches (OK)", size, seeds, matches)
+	}
+}
+
+func Test_PermuteNth(t *testing.T) {
+	size := int64(129)
+	seeds := int64(8)
+	p := make([][]*PermutationGenerator, seeds)
+	seen := make([]map[int64]struct{}, seeds)
+	for s := int64(0); s < seeds; s++ {
+		p[s] = make([]*PermutationGenerator, 2)
+		p[s][0] = permutationGeneratorOrBust(size, s, "", t)
+		p[s][1] = permutationGeneratorOrBust(size, s, "", t)
+		seen[s] = make(map[int64]struct{}, size)
+	}
+	v := make([]int64, seeds)
+	for i := int64(0); i < size; i++ {
+		for s := int64(0); s < seeds; s++ {
+			v[s] = p[s][0].Next()
+			if _, ok := seen[s][v[s]]; ok {
+				t.Fatalf("duplicate entry (size %d, seed %d, entry %d): %d",
+					size, s, i, v[s])
+			}
+			seen[s][v[s]] = struct{}{}
+			vN := p[s][1].Nth(i)
+			if vN != v[s] {
+				t.Fatalf("Nth entry didn't match Nth call to Next()) (size %d, seed %d, n %d): expected %d, got %d\n",
+					size, s, i, v[s], vN)
+			}
+		}
+	}
+}
+
+func Benchmark_PermuteCycle(b *testing.B) {
+	sizes := []int64{5, 63, 1000000, (1 << 19), (1 << 30)}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("Pool%d", size), func(b *testing.B) {
+			p := permutationGeneratorOrBust(size, 0, "", b)
+			for i := 0; i < b.N; i++ {
+				_ = p.Next()
+			}
+			v, h := p.Hits()
+			b.Logf("N %d: %d values, %d hits", b.N, v, h)
+		})
+	}
+}


### PR DESCRIPTION
this is a fancy new permutation generator based on a paper I found about using a streamlined form of the standard knuth shuffle -- basically, a shuffle which only needs to look at one card to determine what will be in that slot after the shuffle, thus, O(1) lookup for the Nth slot, instead of O(N) time/space to compute the whole set. This sounds impossible so I've added a couple of layers of test cases to watch for any shenanigans.

This is slower than the other implementation I was looking at; it wants a number of possible-shuffle operations proportional to log N. So for (1<<30), it's using about 10 microseconds. Probably a fair bit of room for improved optimization, and if we don't care that much about cryptographic levels of security, capping it at 30ish rounds would probably be fine.

This also separates the permutation code out from the rest of tools/bench so I can use it in imagine.