### PR TITLE
Add threadcount flag to command line and allow for multiple hosts

### DIFF
--- a/imagine/README.md
+++ b/imagine/README.md
@@ -42,11 +42,12 @@ The following options change how `imagine` goes about its work:
 *  `--column-scale int`     scale number of columns provided by specs
 *  `--cpu-profile string`   record CPU profile to file
 *  `--dry-run`              dry-run; describe what would be done
-*  `--host string`          host name for Pilosa server (default "localhost")
+*  `--hosts string`         comma-separated host names for Pilosa server (default "localhost")
 *  `--mem-profile string`   record allocation profile to file
 *  `--port int`             host port for Pilosa server (default 10101)
 *  `--prefix string`        prefix to use on index names
 *  `--row-scale int`        scale number of rows provided by specs
+*  `--thread-count int`     number of threads to use for import, overrides value in config file (default 1)
 *  `--time`                 report on time elapsed for operations
 
 ## Spec files

--- a/imagine/main.go
+++ b/imagine/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/pilosa/tools/imagine/imagine"
+	imagine "github.com/pilosa/tools/imagine/pkg"
 )
 
 func main() {

--- a/imagine/pkg/main.go
+++ b/imagine/pkg/main.go
@@ -106,7 +106,7 @@ func (conf *Config) Run() error {
 	return nil
 }
 
-// ReadSpecs reads the files in conf.specFiles and populates fields
+// ReadSpecs reads the files in conf.specFiles and populates fields.
 func (conf *Config) ReadSpecs() error {
 	conf.specs = make([]*tomlSpec, 0, len(conf.specFiles))
 	conf.indexes = make(map[string]*indexSpec, len(conf.specFiles))
@@ -276,7 +276,7 @@ func (conf *Config) Execute() {
 	fmt.Printf("done.\n")
 }
 
-// NewSpecsFiles copies files to config.specFiles
+// NewSpecsFiles copies files to config.specFiles.
 func (conf *Config) NewSpecsFiles(files []string) {
 	conf.specFiles = files
 }

--- a/imagine/pkg/main.go
+++ b/imagine/pkg/main.go
@@ -35,9 +35,9 @@ const (
 
 // Config describes the overall configuration of the tool.
 type Config struct {
-	Host         string `help:"host name for Pilosa server"`
-	Port         int    `help:"host port for Pilosa server"`
-	Verify       string `help:"index structure validation: purge/error/update/create"`
+	Hosts        []string `help:"comma separated host names for Pilosa servers"`
+	Port         int      `help:"host port for Pilosa server"`
+	Verify       string   `help:"index structure validation: purge/error/update/create"`
 	verifyType   verifyType
 	Generate     bool `help:"generate data as specified by workloads"`
 	Delete       bool `help:"delete specified indexes"`
@@ -51,6 +51,7 @@ type Config struct {
 	ColumnScale  int64  `help:"scale number of columns provided by specs"`
 	RowScale     int64  `help:"scale number of rows provided by specs"`
 	LogImports   string `help:"file name to log all imports to (so they can be replayed later)"`
+	ThreadCount  int    `help:"number of threads to use for each import, overrides value set in config file"`
 	flagset      *flag.FlagSet
 	specFiles    []string
 	specs        []*tomlSpec
@@ -68,6 +69,9 @@ func (conf *Config) Run() error {
 	}
 	if int(uint16(conf.Port)) != conf.Port {
 		return fmt.Errorf("port %d out of range", conf.Port)
+	}
+	if conf.ThreadCount < 0 {
+		return fmt.Errorf("invalid thread count %d [must be a positive number]", conf.ThreadCount)
 	}
 	// if not given other instructions, just describe the specs
 	if !conf.Generate && !conf.Delete && conf.Verify == "" {
@@ -89,7 +93,7 @@ func (conf *Config) Run() error {
 			conf.verifyType = verifyTypeError
 		}
 	}
-	conf.specFiles = conf.flagset.Args()
+	conf.NewSpecsFiles(conf.flagset.Args())
 	if len(conf.specFiles) < 1 {
 		return errors.New("must specify one or more spec files")
 	}
@@ -102,7 +106,8 @@ func (conf *Config) Run() error {
 	return nil
 }
 
-func (conf *Config) readSpecs() error {
+// ReadSpecs reads the files in conf.specFiles and populates fields
+func (conf *Config) ReadSpecs() error {
 	conf.specs = make([]*tomlSpec, 0, len(conf.specFiles))
 	conf.indexes = make(map[string]*indexSpec, len(conf.specFiles))
 	for _, path := range conf.specFiles {
@@ -135,11 +140,13 @@ func (conf *Config) readSpecs() error {
 // which can be overridden by command line options.
 func NewConfig() *Config {
 	return &Config{
-		Host:     "localhost",
-		Port:     10101,
-		Generate: true,
-		Verify:   "update",
-		Prefix:   "imaginary-",
+		Hosts:       []string{"localhost"},
+		Port:        10101,
+		Generate:    true,
+		Verify:      "update",
+		Prefix:      "imaginary-",
+		ThreadCount: 0, // if unchanged, uses workloadspec.threadcount
+		// if workloadspec.threadcount is also unset, defaults to 1
 	}
 }
 
@@ -156,7 +163,7 @@ func (conf *Config) Execute() {
 		log.Fatalf("parsing arguments: %s", err)
 	}
 
-	err = conf.readSpecs()
+	err = conf.ReadSpecs()
 	if err != nil {
 		log.Fatalf("config/spec error: %v", err)
 	}
@@ -172,9 +179,13 @@ func (conf *Config) Execute() {
 		}
 	}
 
-	uri, err := pilosa.NewURIFromHostPort(conf.Host, uint16(conf.Port))
-	if err != nil {
-		log.Fatalf("could not create Pilosa URI: %v", err)
+	uris := make([]*pilosa.URI, 0, len(conf.Hosts))
+	for _, host := range conf.Hosts {
+		uri, err := pilosa.NewURIFromHostPort(host, uint16(conf.Port))
+		if err != nil {
+			log.Fatalf("could not create Pilosa URI: %v", err)
+		}
+		uris = append(uris, uri)
 	}
 
 	clientOpts := make([]pilosa.ClientOption, 0)
@@ -186,7 +197,8 @@ func (conf *Config) Execute() {
 		clientOpts = append(clientOpts, pilosa.ExperimentalOptClientLogImports(f))
 	}
 
-	client, err = pilosa.NewClient(uri, clientOpts...)
+	cluster := pilosa.NewClusterWithHost(uris...)
+	client, err := pilosa.NewClient(cluster, clientOpts...)
 	if err != nil {
 		log.Fatalf("could not create Pilosa client: %v", err)
 	}
@@ -262,6 +274,11 @@ func (conf *Config) Execute() {
 	}
 
 	fmt.Printf("done.\n")
+}
+
+// NewSpecsFiles copies files to config.specFiles
+func (conf *Config) NewSpecsFiles(files []string) {
+	conf.specFiles = files
 }
 
 // CompareIndexes is the general form of comparing client and server index

--- a/imagine/pkg/spec.go
+++ b/imagine/pkg/spec.go
@@ -289,7 +289,6 @@ func readSpec(path string) (*tomlSpec, error) {
 	var ts tomlSpec
 	md, err := toml.DecodeFile(path, &ts)
 	if err != nil {
-		fmt.Printf("this err\n")
 		return nil, err
 	}
 	// don't allow keys we haven't heard of

--- a/imagine/pkg/spec.go
+++ b/imagine/pkg/spec.go
@@ -277,12 +277,12 @@ func describeWorkload(wl *workloadSpec) {
 	}
 }
 
-func (t *taskSpec) String() string {
+func (ts *taskSpec) String() string {
 	offset := ""
-	if t.ColumnOffset != 0 {
-		offset = fmt.Sprintf(" starting at %d", t.ColumnOffset)
+	if ts.ColumnOffset != 0 {
+		offset = fmt.Sprintf(" starting at %d", ts.ColumnOffset)
 	}
-	return fmt.Sprintf("%s/%s: %d columns%s", t.Index, t.Field, *t.Columns, offset)
+	return fmt.Sprintf("%s/%s: %d columns%s", ts.Index, ts.Field, *ts.Columns, offset)
 }
 
 func readSpec(path string) (*tomlSpec, error) {
@@ -549,7 +549,9 @@ func (fs *fieldSpec) Cleanup(conf *Config) error {
 // Cleanup performs bookkeeping tasks and error-checking, and calls the
 // Cleanup method of associated batches.
 func (ws *workloadSpec) Cleanup(conf *Config) error {
-	if ws.ThreadCount != nil {
+	if conf.ThreadCount != 0 {
+		ws.ThreadCount = &conf.ThreadCount
+	} else if ws.ThreadCount != nil {
 		if *ws.ThreadCount < 1 {
 			return fmt.Errorf("invalid thread count %d [must be a positive number]", *ws.ThreadCount)
 		}
@@ -567,7 +569,9 @@ func (ws *workloadSpec) Cleanup(conf *Config) error {
 // Cleanup performs bookkeeping tasks, and error-checking, and calls the
 // Cleanup method of associated tasks.
 func (bs *batchSpec) Cleanup(conf *Config) error {
-	if bs.ThreadCount == nil {
+	if conf.ThreadCount != 0 {
+		bs.ThreadCount = &conf.ThreadCount
+	} else if bs.ThreadCount == nil {
 		bs.ThreadCount = bs.Parent.ThreadCount
 	}
 	if bs.BatchSize == nil {


### PR DESCRIPTION
This PR adds the `--thread-count` flag to the command line for imagine and also allows for multiple hosts.

Because the new version takes in a comma-separated string of host addresses, this does not break backwards compatibility with the previous version that only requires one host.

Also some fixes to export some methods and remove annoying go-lint errors. 