### PR TITLE
undo merging error

### DIFF
--- a/imagine/generators_test.go
+++ b/imagine/generators_test.go
@@ -208,8 +208,6 @@ func TestMutexGen(t *testing.T) {
 			DensityScale: uint64p(2097152),
 			Density:      0.9,
 			ValueRule:    densityTypeZipf,
-			ZipfV:        1.0,
-			ZipfS:        1.1,
 			Cache:        cacheTypeLRU,
 			ZipfS:        1.1,
 			ZipfV:        1,


### PR DESCRIPTION
I'm not totally sure how this managed to happen, since it breaks tests
immediately, but apparently one of my fixes for a test clashed with another
one in a way that produced non-compiling tests.